### PR TITLE
更新企业人员回调做了一层部门兼容

### DIFF
--- a/api-server/app/WeWork/EventHandler/WorkEmployee/EmployeeUpdateHandler.php
+++ b/api-server/app/WeWork/EventHandler/WorkEmployee/EmployeeUpdateHandler.php
@@ -101,12 +101,12 @@ class EmployeeUpdateHandler extends AbstractEventHandler
         $orders         = ! empty($this->message['Order']) ? $this->message['Order'] : '';
         if (! empty($this->message['Department']) && ! empty($edepartment)) {
             $wxDepartment = explode(',', $this->message['Department']);
-            if(count($wxDepartment)==1){
+            if (count($wxDepartment) == 1) {
                 //当有且只有一个部门的时候 表示该部门也是主部门
                 //不知道为什么 当部门只有1个的时候 他的MainDepartment 事件儿不返回 不知是否是api触发的缘故 总之做一层兼容保险下
-                $mainDepartmentId=current($wxDepartment);
+                $mainDepartmentId = current($wxDepartment);
                 if ($employee['wxMainDepartmentId'] != $mainDepartmentId) {
-                    $updateEmployee['main_department_id']    = ! empty($department[$mainDepartmentId]) ? $department[$mainDepartmentId] : $employee['mainDepartmentId'];
+                    $updateEmployee['main_department_id'] = !empty($department[$mainDepartmentId]) ? $department[$mainDepartmentId] : $employee['mainDepartmentId'];
                     $updateEmployee['wx_main_department_id'] = $mainDepartmentId;
                 }
             }

--- a/api-server/app/WeWork/EventHandler/WorkEmployee/EmployeeUpdateHandler.php
+++ b/api-server/app/WeWork/EventHandler/WorkEmployee/EmployeeUpdateHandler.php
@@ -101,6 +101,15 @@ class EmployeeUpdateHandler extends AbstractEventHandler
         $orders         = ! empty($this->message['Order']) ? $this->message['Order'] : '';
         if (! empty($this->message['Department']) && ! empty($edepartment)) {
             $wxDepartment = explode(',', $this->message['Department']);
+            if(count($wxDepartment)==1){
+                //当有且只有一个部门的时候 表示该部门也是主部门
+                //不知道为什么 当部门只有1个的时候 他的MainDepartment 事件儿不返回 不知是否是api触发的缘故 总之做一层兼容保险下
+                $mainDepartmentId=current($wxDepartment);
+                if ($employee['wxMainDepartmentId'] != $mainDepartmentId) {
+                    $updateEmployee['main_department_id']    = ! empty($department[$mainDepartmentId]) ? $department[$mainDepartmentId] : $employee['mainDepartmentId'];
+                    $updateEmployee['wx_main_department_id'] = $mainDepartmentId;
+                }
+            }
             //解除成员部门绑定关系
             foreach ($edepartment as $edk => $edv) {
                 if (! in_array($edk, $wxDepartment)) {


### PR DESCRIPTION
当有且只有一个部门的时候 表示该部门也是主部门
不知道为什么 当部门只有1个的时候 他的MainDepartment 事件儿不返回 不知是否是api触发的缘故 总之做一层兼容保险下