### PR TITLE
fix: 修复参与抽奖活动错误

### DIFF
--- a/api-server/plugin/mochat/lottery/src/Action/Operation/ContactLottery.php
+++ b/api-server/plugin/mochat/lottery/src/Action/Operation/ContactLottery.php
@@ -257,7 +257,7 @@ class ContactLottery extends AbstractAction
                         $winCode = $this->lotteryContactRecordService->countLotteryContactRecordReceiveCodeByLotteryIdPrizeName((int) $params['id'], $winName, ['receive_code']);
                         $winCode = array_column($winCode, 'receiveCode');
                         $result = array_merge(array_diff($val['exchange_code'], $winCode));
-                        $data['receive_code'] = $result[0];
+                        $data['receive_code'] = sizeof($result) > 0 ? $result[0] : '';
                     }
                     break;
                 }


### PR DESCRIPTION
手机参与抽奖时，会出现500后台异常的错误，检查日志发现$result为空数组，因此新增对$result长度判断